### PR TITLE
Traefik tlschallenge to dnschallenge

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,12 +37,13 @@ services:
       - --experimental.plugins.rewrite-body.version=v1.2.0
       - --experimental.plugins.rewriteHeaders.modulename=github.com/XciD/traefik-plugin-rewrite-headers
       - --experimental.plugins.rewriteHeaders.version=v0.0.3
+      - --certificatesresolvers.myresolver.acme.dnschallenge=${DNS_CHALLENGE:-true}
+      - --certificatesresolvers.myresolver.acme.dnschallenge.provider=${DNS_CHALLENGE_PROVIDER:-cloudflare}
+      - --certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53
+      - --certificatesresolvers.myresolver.acme.caserver=${LETS_ENCRYPT_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
       # ACME configuration for Let's Encrypt
       - --certificatesresolvers.myresolver.acme.email=${LETS_ENCRYPT_EMAIL}
       - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
-      - --certificatesresolvers.myresolver.acme.tlschallenge=true
-      # TLS configuration for secure entry points
-      - --entrypoints.web-secure.http.tls.certresolver=myresolver
       # Enable Metrics for Prometheus
       - --metrics.prometheus=true
       - --metrics.prometheus.buckets=0.100000,0.300000,1.200000,5.000000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - --experimental.plugins.rewrite-body.version=v1.2.0
       - --experimental.plugins.rewriteHeaders.modulename=github.com/XciD/traefik-plugin-rewrite-headers
       - --experimental.plugins.rewriteHeaders.version=v0.0.3
+      # ACME DNS-01 challenge setup (for obtaining SSL certificates)
       - --certificatesresolvers.myresolver.acme.dnschallenge=${DNS_CHALLENGE:-true}
       - --certificatesresolvers.myresolver.acme.dnschallenge.provider=${DNS_CHALLENGE_PROVIDER:-cloudflare}
       - --certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53


### PR DESCRIPTION
The change you made is switching from using the TLS-ALPN challenge (via tlschallenge) to the DNS-01 challenge (via dnschallenge) for obtaining SSL certificates with Let's Encrypt.
Here's a breakdown of the change:
Before (using TLS-ALPN challenge):

- --certificatesresolvers.myresolver.acme.tlschallenge=true

    TLS-ALPN challenge: This challenge type works by having Traefik (or another ACME client) serve a special certificate over HTTPS (via ALPN) on port 443 to prove domain ownership. The ACME server will check the certificate for a specific value to confirm that Traefik controls the domain.
    This is often the default method for many setups because it only requires HTTP/HTTPS access to validate ownership of a domain, making it relatively simple to implement.

After (using DNS-01 challenge):

# ACME DNS-01 challenge setup (for obtaining SSL certificates)
- --certificatesresolvers.myresolver.acme.dnschallenge=${DNS_CHALLENGE:-true}
- --certificatesresolvers.myresolver.acme.dnschallenge.provider=${DNS_CHALLENGE_PROVIDER:-cloudflare}
- --certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53
- --certificatesresolvers.myresolver.acme.caserver=${LETS_ENCRYPT_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}

    DNS-01 challenge: The DNS challenge works by having Traefik create a DNS TXT record that proves ownership of a domain. The ACME server then checks the DNS record instead of verifying via HTTP/HTTPS traffic.
    The DNS-01 challenge is useful when:
        You want to use wildcard certificates (which require DNS-01).
        You can't expose HTTP endpoints publicly (e.g., behind firewalls or when dealing with multiple services on the same domain).
        You want to automate SSL certificate renewals without relying on HTTP access.

Key components in the new configuration:

    --certificatesresolvers.myresolver.acme.dnschallenge=true: Enables the DNS-01 challenge for Traefik’s ACME resolver.

    --certificatesresolvers.myresolver.acme.dnschallenge.provider=${DNS_CHALLENGE_PROVIDER:-cloudflare}: Specifies the DNS provider (in this case, Cloudflare). The ${DNS_CHALLENGE_PROVIDER} variable is expected to be set to Cloudflare in the environment (or defaults to Cloudflare if not set).

    --certificatesresolvers.myresolver.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53: This line specifies DNS resolvers (Cloudflare’s 1.1.1.1 and Google’s 8.8.8.8), which will be used to resolve DNS challenges.

    --certificatesresolvers.myresolver.acme.caserver=${LETS_ENCRYPT_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}: This sets the ACME server URL for Let's Encrypt (or another CA). The ${LETS_ENCRYPT_CA_SERVER} environment variable can be used to set a custom CA server if desired.

Why make this change?

    Wildcard Certificates: The TLS-ALPN challenge cannot be used for wildcard certificates, while DNS-01 can. By switching to the DNS-01 challenge, you can now request wildcard certificates, which would be important if you want to secure multiple subdomains (e.g., *.example.com).

    Domain Ownership without HTTP Access: If your service is behind a firewall or doesn’t allow public HTTP traffic, DNS-01 is a better option since it only requires DNS changes to verify domain ownership rather than needing HTTP endpoints accessible over the internet.

    More Control over DNS Providers: With the DNS-01 challenge, you can directly manage the DNS records via an API (like Cloudflare’s DNS API), giving you more flexibility and automation over your certificates.

Summary:

The change you made switches the challenge method for obtaining SSL certificates from TLS-ALPN (which relies on HTTPS to verify domain ownership) to DNS-01 (which relies on DNS records to prove domain ownership). This change allows you to use DNS-01 to obtain wildcard certificates and is more suitable if you need greater control over DNS or if HTTP access is restricted.